### PR TITLE
Add command line option to specify wireguard port

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ $ subspace --http-host subspace.example.com
         enable sessions cookies for http (no https) not recommended
   -letsencrypt
         enable TLS using Let's Encrypt on port 443 (default true)
+  -wg-port
+        change the port the WireGuard server listens on (default 51820)
   -version
         display version and exit
 ```

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ $ subspace --http-host subspace.example.com
         enable sessions cookies for http (no https) not recommended
   -letsencrypt
         enable TLS using Let's Encrypt on port 443 (default true)
-  -wg-port
-        change the port the WireGuard server listens on (default 51820)
+  -wg-port int
+    	the port wireguard listens on (default 51820)
   -version
         display version and exit
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,6 +27,10 @@ if [ -z "${SUBSPACE_HTTP_INSECURE-}" ] ; then
     export SUBSPACE_HTTP_INSECURE="false"
 fi
 
+if [ -z "${SUBSPACE_WIREGUARD_PORT-}" ] ; then
+    export SUBSPACE_WIREGUARD_PORT="51820"
+fi
+
 export NAMESERVER="1.1.1.1"
 export DEBIAN_FRONTEND="noninteractive"
 
@@ -109,7 +113,7 @@ fi
 cat <<WGSERVER >/data/wireguard/server.conf
 [Interface]
 PrivateKey = $(cat /data/wireguard/server.private)
-ListenPort = 51820
+ListenPort = $SUBSPACE_WIREGUARD_PORT
 
 WGSERVER
 cat /data/wireguard/peers/*.conf >>/data/wireguard/server.conf
@@ -164,7 +168,8 @@ exec /usr/bin/subspace \
     "--http-addr=${SUBSPACE_HTTP_ADDR}" \
     "--http-insecure=${SUBSPACE_HTTP_INSECURE}" \
     "--backlink=${SUBSPACE_BACKLINK}" \
-    "--letsencrypt=${SUBSPACE_LETSENCRYPT}"
+    "--letsencrypt=${SUBSPACE_LETSENCRYPT}" \
+	"--wg-port=${SUBSPACE_WIREGUARD_PORT}
 RUNIT
     chmod +x /etc/sv/subspace/run
 

--- a/handlers.go
+++ b/handlers.go
@@ -387,7 +387,7 @@ Address = 10.99.97.{{$.Profile.Number}}/22,fd00::10:97:{{$.Profile.Number}}/112
 
 [Peer]
 PublicKey = $(cat server.public)
-Endpoint = {{$.Domain}}:51820
+Endpoint = {{$.Domain}}:{{$.WgPort}}
 AllowedIPs = 0.0.0.0/0, ::/0
 WGCLIENT
 `
@@ -395,10 +395,12 @@ WGCLIENT
 		Datadir string
 		Profile Profile
 		Domain  string
+        WgPort int
 	}{
 		datadir,
 		profile,
 		httpHost,
+        wgPort,
 	})
 	if err != nil {
 		logger.Warn(err)

--- a/handlers.go
+++ b/handlers.go
@@ -395,12 +395,12 @@ WGCLIENT
 		Datadir string
 		Profile Profile
 		Domain  string
-        WgPort int
+		WgPort int
 	}{
 		datadir,
 		profile,
 		httpHost,
-        wgPort,
+		wgPort,
 	})
 	if err != nil {
 		logger.Warn(err)

--- a/main.go
+++ b/main.go
@@ -83,6 +83,9 @@ var (
 
 	// Error page HTML
 	errorPageHTML = `<html><head><title>Error</title></head><body text="orangered" bgcolor="black"><h1>An error has occurred</h1></body></html>`
+
+    // Port WireGuard server listens on
+    wgPort = 51820
 )
 
 func init() {
@@ -95,6 +98,7 @@ func init() {
 	cli.BoolVar(&showVersion, "version", false, "display version and exit")
 	cli.BoolVar(&showHelp, "help", false, "display help and exit")
 	cli.BoolVar(&debug, "debug", false, "debug mode")
+    cli.IntVar(&wgPort, "wg-port", 51820, "the port wireguard listens on")
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ var (
 	errorPageHTML = `<html><head><title>Error</title></head><body text="orangered" bgcolor="black"><h1>An error has occurred</h1></body></html>`
 
     // Port WireGuard server listens on
-    wgPort = 51820
+	wgPort = 51820
 )
 
 func init() {
@@ -98,7 +98,7 @@ func init() {
 	cli.BoolVar(&showVersion, "version", false, "display version and exit")
 	cli.BoolVar(&showHelp, "help", false, "display help and exit")
 	cli.BoolVar(&debug, "debug", false, "debug mode")
-    cli.IntVar(&wgPort, "wg-port", 51820, "the port wireguard listens on")
+	cli.IntVar(&wgPort, "wg-port", 51820, "the port wireguard listens on")
 }
 
 func main() {


### PR DESCRIPTION
While the default (51820) might work for some, I was already using that port on my network. I was surprised to see that it wasn't possible to change the port Wireguard will be configured to listen on.

This pull request adds a command line option to change the port as well as adding an environment variable for the Dockerfile (`SUBSPACE_WIREGUARD_PORT`)