### PR TITLE
Various build improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+subspace-linux-amd64
+bindata.go

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -5,23 +5,10 @@ RUN apt-get update \
     && apt-get install -y git \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /go/src/github.com/subspacecloud/subspace
+WORKDIR /src
 
-RUN go get -v \
-    github.com/jteeuwen/go-bindata/... \
-    github.com/dustin/go-humanize \
-    github.com/julienschmidt/httprouter \
-    github.com/sirupsen/logrus \
-    github.com/gorilla/securecookie \
-    golang.org/x/crypto/acme/autocert \
-    golang.org/x/time/rate \
-	golang.org/x/crypto/bcrypt \
-    go.uber.org/zap \
-	gopkg.in/gomail.v2 \
-    github.com/crewjam/saml \
-    github.com/dgrijalva/jwt-go \
-    github.com/skip2/go-qrcode
-
+# go.mod and go.sum if exists
+COPY go.* ./
 COPY *.go ./
 COPY static ./static
 COPY templates ./templates
@@ -30,9 +17,8 @@ COPY email ./email
 ARG BUILD_VERSION=unknown
 
 ENV GODEBUG="netdns=go http2server=0"
-ENV GOPATH="/go"
 
-RUN go-bindata --pkg main static/... templates/... email/... \
+RUN go generate \
     && go fmt \
     && go vet --all
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -11,7 +11,7 @@ RUN go get -v \
     github.com/jteeuwen/go-bindata/... \
     github.com/dustin/go-humanize \
     github.com/julienschmidt/httprouter \
-    github.com/Sirupsen/logrus \
+    github.com/sirupsen/logrus \
     github.com/gorilla/securecookie \
     golang.org/x/crypto/acme/autocert \
     golang.org/x/time/rate \

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -2,11 +2,12 @@ FROM golang:1.11.5
 MAINTAINER github.com/subspacecloud/subspace
 
 RUN apt-get update \
-    && apt-get install -y git \
+    && apt-get install -y git make \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src
 
+COPY Makefile ./
 # go.mod and go.sum if exists
 COPY go.* ./
 COPY *.go ./
@@ -18,9 +19,5 @@ ARG BUILD_VERSION=unknown
 
 ENV GODEBUG="netdns=go http2server=0"
 
-RUN go generate \
-    && go fmt \
-    && go vet --all
-
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
-    go build -v --compiler gc --ldflags "-extldflags -static -s -w -X main.version=${BUILD_VERSION}" -o /usr/bin/subspace-linux-amd64
+RUN make BUILD_VERSION=${BUILD_VERSION}
+RUN mv subspace-linux-amd64 /usr/bin/subspace-linux-amd64

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+all: subspace-linux-amd64
+
+BUILD_VERSION?=unknown
+
+subspace-linux-amd64:
+	go generate \
+	&& go fmt \
+	&& go vet --all
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+	go build -v --compiler gc --ldflags "-extldflags -static -s -w -X main.version=${BUILD_VERSION}" -o subspace-linux-amd64
+
+clean:
+	rm -f subspace-linux-amd64 bindata.go
+
+.PHONY: clean

--- a/assets.go
+++ b/assets.go
@@ -1,0 +1,7 @@
+package main
+
+import (
+	_ "github.com/jteeuwen/go-bindata"
+)
+
+//go:generate go run github.com/jteeuwen/go-bindata/go-bindata --pkg main static/... templates/... email/...

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,17 @@
+module github.com/subspacecloud/subspace
+
+require (
+	github.com/beevik/etree v1.1.0 // indirect
+	github.com/crewjam/saml v0.0.0-20190521120225-344d075952c9
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/dustin/go-humanize v1.0.0
+	github.com/gorilla/securecookie v1.1.1
+	github.com/jonboulle/clockwork v0.1.0 // indirect
+	github.com/julienschmidt/httprouter v1.3.0
+	github.com/russellhaering/goxmldsig v0.0.0-20180430223755-7acd5e4a6ef7 // indirect
+	github.com/sirupsen/logrus v1.4.2
+	github.com/skip2/go-qrcode v0.0.0-20190110000554-dc11ecdae0a9
+	golang.org/x/crypto v0.0.0-20191010185427-af544f31c8ac
+	golang.org/x/net v0.0.0-20191009170851-d66e71096ffb
+	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
+)

--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,14 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/gorilla/securecookie v1.1.1
 	github.com/jonboulle/clockwork v0.1.0 // indirect
+	github.com/jteeuwen/go-bindata v3.0.8-0.20180305030458-6025e8de665b+incompatible
 	github.com/julienschmidt/httprouter v1.3.0
+	github.com/kr/pretty v0.1.0 // indirect
 	github.com/russellhaering/goxmldsig v0.0.0-20180430223755-7acd5e4a6ef7 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/skip2/go-qrcode v0.0.0-20190110000554-dc11ecdae0a9
 	golang.org/x/crypto v0.0.0-20191010185427-af544f31c8ac
 	golang.org/x/net v0.0.0-20191009170851-d66e71096ffb
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
 )

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/julienschmidt/httprouter"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
 	"github.com/gorilla/securecookie"

--- a/main.go
+++ b/main.go
@@ -19,10 +19,10 @@ import (
 
 	"github.com/julienschmidt/httprouter"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
 	"github.com/gorilla/securecookie"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/acme/autocert"
 )
 


### PR DESCRIPTION
* Switch to using go modules
  * `go build`does the right thing
  * Note: I did not check _go.sum_ in, but it can also be done
* Use _go-bindata_ via `go generate`
  * _go-bindata_ is fetched as any other dependency
* Decouple build logic from the container
 * Allows to build the same without the container. Put the logic in a Makefile and use that in the container
  * Note that in any case there is no need for `go get`anymore