### PR TITLE
Allow user to set DNS server

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,10 @@ if [ -z "${SUBSPACE_HTTP_INSECURE-}" ] ; then
     export SUBSPACE_HTTP_INSECURE="false"
 fi
 
-export NAMESERVER="1.1.1.1"
+if [ -z "${NAMESERVER-}" ] ; then
+    export NAMESERVER="1.1.1.1"
+fi
+
 export DEBIAN_FRONTEND="noninteractive"
 
 # Set DNS server


### PR DESCRIPTION
Allows the user to set the nameserver by setting the 'NAMESERVER' environment variable to the value of their choice. Defaults to Cloudflare DNS. 

Solves #41.